### PR TITLE
Bao/voice

### DIFF
--- a/apps/dashboard/src/components/Playbar.tsx
+++ b/apps/dashboard/src/components/Playbar.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '@src/context/AuthProvider'
 import { usePlayStatus } from '@src/context/PlayStatus'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faHeart } from '@fortawesome/free-solid-svg-icons'
+import useSpeechRecognition from '@src/hooks/useSpeechRecognition'
 
 interface PlaybarProps {
   imageUrl: string | null
@@ -38,37 +39,68 @@ const Playbar: React.FC<PlaybarProps> = ({
   isFavorite,
   onFavorite,
 }) => {
-  const [micActive, setMicActive] = useState(false)
+  // const [micActive, setMicActive] = useState(false)
   const { user } = useAuth()
   const { isPlaying, setIsPlaying } = usePlayStatus()
+
+  const { text, isListening, setIsListening, startListening, stopListening, hasRecognitionSupport } = useSpeechRecognition()
+
   const styleDefault = ''
   const styleActive = 'fill-icon-active dark:fill-icon-active-dark'
 
+  useEffect(() => {
+    if (text === 'play') {
+      handlePlayPause()
+    } else if (text === 'pause') {
+      handlePlayPause()
+    } else if (text === 'stop') {
+      handleStop()
+    } else if (text === 'forward') {
+      handleFastForward()
+    } else if (text === 'backward' || text === 'rewind') {
+      handleRewind()
+    }
+  }, [text])
+
+  const handleStop = () => {
+      //TODO: cancel speech
+  }
+
   const handlePlayPause = () => {
     if (isPlaying) {
-      onAction('stop')
+      //TODO: pause speech
     } else {
-      onAction('start')
+      //TODO: play/resume speech
     }
     setIsPlaying(!isPlaying)
   }
 
   const handleMicrophoneClick = () => {
-    setMicActive(!micActive)
+    if (isListening) {
+      stopListening()
+    } else {
+      startListening()
+    }
   }
 
   const handleRewind = () => {
+    let newExerciseIndex = null
     if (currentExerciseIndex > 0) {
-      setCurrentExerciseIndex(currentExerciseIndex - 1)
-      onAction('rewind')
+      newExerciseIndex = currentExerciseIndex - 1
+      setCurrentExerciseIndex(newExerciseIndex)
+      exerciseName = exercises[newExerciseIndex]
     }
+    //TODO: speak new exercise
   }
 
   const handleFastForward = () => {
+    let newExerciseIndex = null
     if (currentExerciseIndex < exercises.length - 1) {
-      setCurrentExerciseIndex(currentExerciseIndex + 1)
-      onAction('forward')
+      newExerciseIndex = currentExerciseIndex + 1
+      setCurrentExerciseIndex(newExerciseIndex)
+      exerciseName = exercises[newExerciseIndex].name
     }
+    //TODO: speak new exercise
   }
 
   return (
@@ -123,13 +155,20 @@ const Playbar: React.FC<PlaybarProps> = ({
                 <IoPlay className={styleActive} size="1.5em" />
               )}
             </button>
-            <button onClick={handleMicrophoneClick}>
-              {micActive ? (
-                <AiFillAudio className={styleActive} size="1.5em" />
-              ) : (
-                <AiOutlineAudio className={styleActive} size="1.5em" />
-              )}
-            </button>
+            {hasRecognitionSupport && (
+              <div className='flex flex-row items-center'>
+                <button onClick={handleMicrophoneClick}>
+                  {isListening ? (
+                    <AiFillAudio className={styleActive} size="1.5em" />
+                  ) : (
+                    <AiOutlineAudio className={styleActive} size="1.5em" />
+                  )}
+                </button>
+                <p className='dark:text-secondary-dark text-sm'>{isListening ? 'unmuted' : 'muted'}</p>
+              </div>
+            )
+
+            }
           </div>
         </div>
       )}

--- a/apps/dashboard/src/components/Workout/Header.tsx
+++ b/apps/dashboard/src/components/Workout/Header.tsx
@@ -18,8 +18,6 @@ interface RoutineHeaderProps {
   currentTab: string
   setTab: (tab: string) => void
   onFavorite: () => void
-  onAction: (action: string) => void
-  handlePlayStatus: (action: string) => void
 }
 
 export default function RoutineHeader({
@@ -31,11 +29,10 @@ export default function RoutineHeader({
   currentTab,
   setTab,
   onFavorite,
-  onAction,
-  handlePlayStatus
 }: RoutineHeaderProps) {
-  const { speechStatus } = useSpeech()
   const { isPlaying, setIsPlaying } = usePlayStatus()
+  const { synthRef, speech, setSpeech } = useSpeech()
+  const synth = synthRef.current
 
   return (
     <div className="dark:bg-background-dark flex w-full flex-col items-center space-y-2 border-b border-black bg-[#d9d9d9] p-3">
@@ -54,27 +51,25 @@ export default function RoutineHeader({
           </div>
         </div>
         <div className="space-x-5">
-          {speechStatus === 'speaking' && (
+          {isPlaying && (
             <button
               type="button"
               onClick={() => {
-                onAction('stop')
-                setIsPlaying(false)
+                // TODO: handleStop()
               }}
             >
               <FontAwesomeIcon icon={faStop} className="fa-lg" />
             </button>
           )}
-          {speechStatus === 'ended' && (
+          {!isPlaying && (
             <button
               type="button"
               onClick={() => {
-                onAction('start')
-                setIsPlaying(true)
+                // TODO: handlePlay()
               }}
             >
               <FontAwesomeIcon
-                icon={isPlaying ? faStop : faPlay}
+                icon={faPlay}
                 className="fa-lg"
               />
             </button>

--- a/apps/dashboard/src/components/Workout/Header.tsx
+++ b/apps/dashboard/src/components/Workout/Header.tsx
@@ -8,6 +8,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import { useSpeech } from '@src/context/SpeechProvider'
 import { usePlayStatus } from '@src/context/PlayStatus'
+import { useSpeechActions } from '@src/context/SpeechAction'
 
 interface RoutineHeaderProps {
   name: string
@@ -30,9 +31,8 @@ export default function RoutineHeader({
   setTab,
   onFavorite,
 }: RoutineHeaderProps) {
-  const { isPlaying, setIsPlaying } = usePlayStatus()
-  const { synthRef, speech, setSpeech } = useSpeech()
-  const synth = synthRef.current
+  const { isPlaying } = usePlayStatus()
+  const { handleStop, handlePlay } = useSpeechActions()
 
   return (
     <div className="dark:bg-background-dark flex w-full flex-col items-center space-y-2 border-b border-black bg-[#d9d9d9] p-3">
@@ -54,9 +54,7 @@ export default function RoutineHeader({
           {isPlaying && (
             <button
               type="button"
-              onClick={() => {
-                // TODO: handleStop()
-              }}
+              onClick={handleStop}
             >
               <FontAwesomeIcon icon={faStop} className="fa-lg" />
             </button>
@@ -64,9 +62,7 @@ export default function RoutineHeader({
           {!isPlaying && (
             <button
               type="button"
-              onClick={() => {
-                // TODO: handlePlay()
-              }}
+              onClick={handlePlay}
             >
               <FontAwesomeIcon
                 icon={faPlay}

--- a/apps/dashboard/src/context/PlayStatus.tsx
+++ b/apps/dashboard/src/context/PlayStatus.tsx
@@ -3,11 +3,15 @@ import { createContext, useContext, useState } from 'react'
 interface PlayStatusContextData {
   isPlaying: boolean
   setIsPlaying: React.Dispatch<React.SetStateAction<boolean>>
+  isListening: boolean
+  setIsListening: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 const PlayStatusContext = createContext<PlayStatusContextData>({
   isPlaying: false,
   setIsPlaying: () => {},
+  isListening: false,
+  setIsListening: () => {},
 })
 
 export const usePlayStatus = () => {
@@ -20,9 +24,10 @@ interface PlayStatusProviderProps {
 
 export const PlayStatusProvider: React.FC<PlayStatusProviderProps> = ({ children }) => {
   const [isPlaying, setIsPlaying] = useState(false)
+  const [isListening, setIsListening] = useState(false)
 
   return (
-    <PlayStatusContext.Provider value={{ isPlaying, setIsPlaying }}>
+    <PlayStatusContext.Provider value={{ isPlaying, setIsPlaying, isListening, setIsListening }}>
       {children}
     </PlayStatusContext.Provider>
   )

--- a/apps/dashboard/src/context/SpeechAction.ts
+++ b/apps/dashboard/src/context/SpeechAction.ts
@@ -1,31 +1,153 @@
-import { useCallback } from 'react'
+import useSpeechRecognition from '@src/hooks/useSpeechRecognition'
+import { useCallback, useEffect } from 'react'
+import { usePlayStatus } from './PlayStatus'
+import { getUtterance, useSpeech } from './SpeechProvider'
 
 type Exercise = {
   name: string
 }
 
-export const useSpeechActions = (
-  synth: SpeechSynthesis,
-  exercises: Exercise[]
-) => {
-  const speakExercise = useCallback(
-    (exerciseIndex: number) => {
-      const voices = synth.getVoices()
-      const defaultVoice = voices.find(
-        (voice) => voice.default && voice.lang === 'en-US'
-      )
+// export const useSpeechActions = (
+//   synth: SpeechSynthesis,
+//   exercises: Exercise[]
+// ) => {
+//   const speakExercise = useCallback(
+//     (exerciseIndex: number) => {
+//       const voices = synth.getVoices()
+//       const defaultVoice = voices.find(
+//         (voice) => voice.default && voice.lang === 'en-US'
+//       )
 
-      if (exerciseIndex >= 0 && exerciseIndex < exercises.length) {
-        const exercise = exercises[exerciseIndex]
-        const utterThis = new SpeechSynthesisUtterance(
-          `Exercise ${exerciseIndex + 1}: ${exercise.name}`
-        )
-        utterThis.voice = defaultVoice
-        synth.speak(utterThis)
+//       if (exerciseIndex >= 0 && exerciseIndex < exercises.length) {
+//         const exercise = exercises[exerciseIndex]
+//         const utterThis = new SpeechSynthesisUtterance(
+//           `Exercise ${exerciseIndex + 1}: ${exercise.name}`
+//         )
+//         utterThis.voice = defaultVoice
+//         synth.speak(utterThis)
+//       }
+//     },
+//     [synth, exercises]
+//   )
+
+//   return { speakExercise }
+// }
+
+export const useSpeechActions = () => {
+  const { synthRef, speech, setSpeech } = useSpeech()
+  const { isPlaying, setIsPlaying, isListening} = usePlayStatus()
+  const { text, setText, startListening, stopListening } = useSpeechRecognition()
+
+  const synth = synthRef.current
+  const routineName = speech.routineName
+  const exercises = speech.exercises
+  const currentExerciseIndex = speech.currentExerciseIndex
+
+  useEffect(() => {
+    if (text === 'play') {
+      handlePlay()
+    } else if (text === 'pause') {
+      handlePause()
+    } else if (text === 'stop') {
+      handleStop()
+    } else if (text === 'forward') {
+      handleFastForward()
+    } else if (text === 'rewind') {
+      handleRewind()
+    } 
+  }, [text])
+
+  const startUtterance = getUtterance(`Start ${routineName}.`)
+  const exerciseUtterances: SpeechSynthesisUtterance[] = exercises.map((exercise: any, index: number) => getUtterance(`Exercise ${index + 1}: ${exercise.name}`))
+  const finishUtterance = getUtterance(`. Finished routine`)
+  if (finishUtterance) {
+    finishUtterance.onend = () => {
+      setSpeech({ ...speech, currentExerciseIndex: 0 }) // return to first exercise
+      setIsPlaying(false)
+      setText('') // reset voice command
+    }
+  }
+
+
+  const speakExercise = (currentExerciseIndex: number) => {
+    const utterance = exerciseUtterances[currentExerciseIndex]
+    synth.speak(utterance)
+    utterance.onend = () => {
+      if (currentExerciseIndex < exercises.length - 1) {
+        setSpeech({ ...speech, currentExerciseIndex: currentExerciseIndex + 1 })
+        speakExercise(currentExerciseIndex + 1)
+      } else {
+        synth.speak(finishUtterance)
       }
-    },
-    [synth, exercises]
-  )
+    }
+  }
 
-  return { speakExercise }
+  const handlePlay = () => {
+    if (exerciseUtterances.length > 0) {
+      if (!synth.speaking) {
+        // start routine from beginning
+        synth.speak(startUtterance)
+        speakExercise(currentExerciseIndex)
+      } else {
+        if (synth.paused) {
+          synth.resume()
+        }
+      }
+      setIsPlaying(true)
+    } else {
+      synth.speak(getUtterance(`This routine has no exercises`))
+    }
+  }
+  
+  const handlePause = () => {
+    if (synth.speaking && !synth.paused) {
+      synth.pause()
+    }
+    setIsPlaying(false)
+  }
+
+  const handleStop = () => {
+    // cancel speech
+    synth.cancel()
+    setSpeech({ ...speech, currentExerciseIndex: 0 })
+    setIsPlaying(false)
+  }
+  
+  const handleRewind = () => {
+    let newExerciseIndex = currentExerciseIndex
+    if (currentExerciseIndex > 0) {
+      newExerciseIndex = currentExerciseIndex - 1
+      setSpeech({ ...speech, currentExerciseIndex: newExerciseIndex })
+    }
+    //speak new exercise
+    synth.cancel() // clear queue
+    if (!isPlaying) {
+      setIsPlaying(true)
+    }
+    speakExercise(newExerciseIndex)
+  }
+
+  const handleFastForward = () => {
+    let newExerciseIndex = currentExerciseIndex
+    if (currentExerciseIndex < exercises.length - 1) {
+      newExerciseIndex = currentExerciseIndex + 1
+      setSpeech({ ...speech, currentExerciseIndex: newExerciseIndex })
+    }
+    //speak new exercise
+    synth.cancel()
+    if (!isPlaying) {
+      setIsPlaying(true)
+    }
+    speakExercise(newExerciseIndex)
+  }
+
+  const handleMicrophoneClick = () => {
+    if (isListening) {
+      stopListening()
+    } else {
+      startListening()
+    }
+  }
+
+  return { handlePlay, handlePause, handleStop, handleFastForward, handleRewind, handleMicrophoneClick}
 }

--- a/apps/dashboard/src/context/SpeechProvider.tsx
+++ b/apps/dashboard/src/context/SpeechProvider.tsx
@@ -17,7 +17,8 @@ const defaultSpeech : any = {
     voices: [],
     defaultVoice: undefined,
     utterance: undefined,
-    currentRoutineId: 0,
+    routineName: '',
+    exercises: [],
     currentExerciseIndex: 0
 }
 
@@ -31,11 +32,9 @@ export const SpeechProvider = ({ children }: any) => {
     useEffect(() => {
         if (typeof window !== 'undefined') {
             const storedSpeechInfo = JSON.parse(localStorage.getItem('speechInfo'))
-            if (!storedSpeechInfo) {
-                localStorage.setItem('speechInfo', JSON.stringify({currentRoutineId: 0, currentExerciseIndex: 0}))
-            }
-            const currentRoutineId = storedSpeechInfo.currentRoutineId || 0
-            const currentExerciseIndex = storedSpeechInfo.currentExerciseIndex || 0
+            const routineName = storedSpeechInfo?.routineName || ''
+            const exercises = storedSpeechInfo?.exercises || []
+            const currentExerciseIndex = storedSpeechInfo?.currentExerciseIndex || 0
             synthRef.current = window.speechSynthesis
             const voices = synthRef.current.getVoices()
             const defaultVoice = voices.find(
@@ -43,7 +42,7 @@ export const SpeechProvider = ({ children }: any) => {
                   voice.default && voice.lang === 'en-US'
               )
             const utterance = getUtterance('', defaultVoice)
-            setSpeech({voices, defaultVoice, utterance, currentRoutineId, currentExerciseIndex})
+            setSpeech({voices, defaultVoice, routineName, exercises, currentExerciseIndex})
         }
     },[])
 

--- a/apps/dashboard/src/hooks/useSpeechRecognition.ts
+++ b/apps/dashboard/src/hooks/useSpeechRecognition.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect } from "react"
+
+let recognition: SpeechRecognition = null
+
+
+const useSpeechRecognition = () => {
+    const [text, setText] = useState('')
+    const [isListening, setIsListening] = useState(false)
+
+    // initialize when the component is first loaded
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            if ('webkitSpeechRecognition' in window) {
+                const speechRecognitionList = new webkitSpeechGrammarList()
+                const grammar = '#JSGF V1.0; grammar voiceCommands; public <command> = play | pause | stop | forward | backward | rewind ;';
+                recognition = new webkitSpeechRecognition()
+                speechRecognitionList.addFromString(grammar, 1)
+                recognition.grammars = speechRecognitionList
+                recognition.continuous = false
+                recognition.lang = 'en-US'
+                recognition.interimResults = false
+                recognition.maxAlternatives = 1
+                
+                recognition.onresult = (event: SpeechRecognitionEvent) => {
+                    const voiceCommand = event.results[0][0].transcript
+                    const validCommands = ['play', 'pause', 'stop', 'forward', 'backward', 'rewind', 'mute'] 
+                    if (validCommands.includes(voiceCommand)) {
+                        setText(voiceCommand)
+                        console.log('valid')
+                    } else { console.log('invalid voice command')}
+                    console.log(voiceCommand)
+                    recognition.stop()
+                    setIsListening(false)
+                    if (voiceCommand === 'mute') {
+                        recognition.onend = () => {
+                            console.log('turned off microphone')
+                        }
+                    } else {
+                        recognition.onend = () => {
+                            startListening()
+                        }
+                    }
+                }
+            }
+            if (!recognition) return
+
+        }
+    }, [])
+
+    const startListening = () => {
+        setIsListening(true)
+        recognition.start()
+    }
+
+    const stopListening = () => {
+        setIsListening(false)
+        recognition.stop()
+    }
+
+    return {
+        text, isListening, setIsListening, startListening, stopListening, hasRecognitionSupport: !!recognition
+    }
+
+}
+
+export default useSpeechRecognition

--- a/apps/dashboard/src/hooks/useSpeechRecognition.ts
+++ b/apps/dashboard/src/hooks/useSpeechRecognition.ts
@@ -23,7 +23,7 @@ const useSpeechRecognition = () => {
                 
                 recognition.onresult = (event: SpeechRecognitionEvent) => {
                     const voiceCommand = event.results[0][0].transcript
-                    const validCommands = ['play', 'pause', 'stop', 'forward', 'backward', 'rewind', 'mute'] 
+                    const validCommands = ['play', 'pause', 'stop', 'forward', 'rewind', 'mute'] 
                     if (validCommands.includes(voiceCommand)) {
                         setText(voiceCommand)
                         console.log('valid')
@@ -58,7 +58,7 @@ const useSpeechRecognition = () => {
     }
 
     return {
-        text, isListening, setIsListening, startListening, stopListening, hasRecognitionSupport: !!recognition
+        text, setText, isListening, setIsListening, startListening, stopListening, hasRecognitionSupport: !!recognition
     }
 
 }

--- a/apps/dashboard/src/hooks/useSpeechRecognition.ts
+++ b/apps/dashboard/src/hooks/useSpeechRecognition.ts
@@ -1,3 +1,4 @@
+import { usePlayStatus } from "@src/context/PlayStatus"
 import { useState, useEffect } from "react"
 
 let recognition: SpeechRecognition = null
@@ -5,7 +6,7 @@ let recognition: SpeechRecognition = null
 
 const useSpeechRecognition = () => {
     const [text, setText] = useState('')
-    const [isListening, setIsListening] = useState(false)
+    const { isListening, setIsListening } = usePlayStatus()
 
     // initialize when the component is first loaded
     useEffect(() => {
@@ -29,8 +30,6 @@ const useSpeechRecognition = () => {
                         console.log('valid')
                     } else { console.log('invalid voice command')}
                     console.log(voiceCommand)
-                    recognition.stop()
-                    setIsListening(false)
                     if (voiceCommand === 'mute') {
                         recognition.onend = () => {
                             console.log('turned off microphone')
@@ -40,6 +39,8 @@ const useSpeechRecognition = () => {
                             startListening()
                         }
                     }
+                    recognition.stop()
+                    setIsListening(false)
                 }
             }
             if (!recognition) return


### PR DESCRIPTION
- Moved speech and voice controls to useSpeechActions hook for reusability (i.e. used by both the routine header and the play bar) -> much easier to control compared to passing callback functions as props
- Able to control the play bar with voice commands: 'play', 'pause', 'stop', 'forward', 'rewind', 'mute'
- Once unmuted, microphone can keep receiving voice commands until getting 'mute' command
- If the user navigates to another routine while the current routine is being spoken, the speechSynthesis will stop the current speech and start speaking the new one
- After finish or stop a routine, the speech will be reset